### PR TITLE
以toml的方式指定训练参数

### DIFF
--- a/toml/config_file.toml
+++ b/toml/config_file.toml
@@ -1,0 +1,63 @@
+[model_arguments]
+v2 = false
+v_parameterization = false
+pretrained_model_name_or_path = "./sd-models/model.ckpt"
+
+[additional_network_arguments]
+unet_lr = 0.0001
+text_encoder_lr = 1e-5
+network_dim = 32
+network_alpha = 16.0
+network_train_unet_only = false
+network_train_text_encoder_only = false
+network_module = "networks.lora"
+network_args = []
+
+[optimizer_arguments]
+optimizer_type = "AdamW8bit"
+lr_scheduler = "cosine_with_restarts"
+lr_warmup_steps = 0
+lr_restart_cycles = 1
+learning_rate = 0.0001
+
+[dataset_arguments]
+cache_latents = true
+shuffle_caption = true
+enable_bucket = true
+
+[training_arguments]
+batch_size = 1
+noise_offset = 0.1
+keep_tokens = 0
+min_bucket_reso = 256
+max_bucket_reso = 1024
+caption_extension = ".txt"
+max_token_length = 225
+seed = 1337
+xformers = true
+lowram = false
+max_train_epochs = 10
+resolution = "512,512"
+clip_skip = 2
+mixed_precision = "fp16"
+save_precision = "fp16"
+
+[sample_prompt_arguments]
+sample_sampler = "euler_a"
+sample_every_n_epochs = 1
+
+[dreambooth_arguments]
+train_data_dir = "./train/input"
+reg_data_dir = ""
+prior_loss_weight = 0.3
+
+[saving_arguments]
+output_name = "output_name"
+save_every_n_epochs = 1
+save_n_epoch_ratio = 0
+save_last_n_epochs = 499
+save_state = false
+save_model_as = "safetensors"
+output_dir = "./output"
+logging_dir = "./output/logs"
+log_prefix = "output_name"

--- a/toml/sample_prompts.txt
+++ b/toml/sample_prompts.txt
@@ -1,0 +1,1 @@
+(masterpiece, best quality, hires:1.2), 1girl, solo,  --n (worst quality, bad quality:1.4), lowres, bad anatomy, bad hands, text, error, missing fingers, extra digit, fewer digits, cropped, worst quality, low quality, normal quality, jpeg artifacts,signature, watermark, username, blurry,  --w 512  --h 768  --l 7  --s 24  --d 1337

--- a/train_by_toml.ps1
+++ b/train_by_toml.ps1
@@ -1,0 +1,33 @@
+# LoRA train script by @Akegarasu
+
+$multi_gpu = 0		 # multi gpu | 多显卡训练 该参数仅限在显卡数 >= 2 使用
+$config_file = "./toml/config_file.toml"		 # config_file | 使用toml文件指定训练参数
+$sample_prompts = "./toml/sample_prompts.txt"		 # sample_prompts | 采样prompts文件,留空则不启用采样功能
+$utf8 = 1		 # utf8 | 使用utf-8编码读取toml；以utf-8编码编写的、含中文的toml必须开启
+
+
+# ============= DO NOT MODIFY CONTENTS BELOW | 请勿修改下方内容 =====================
+
+# Activate python venv
+.\venv\Scripts\activate
+
+$Env:HF_HOME = "huggingface"
+
+$ext_args = [System.Collections.ArrayList]::new()
+$launch_args = [System.Collections.ArrayList]::new()
+
+if ($multi_gpu) {
+  [void]$launch_args.Add("--multi_gpu")
+}
+if ($utf8 -eq 1) {
+  $Env:PYTHONUTF8=1
+}
+
+# run train
+accelerate launch $launch_args --num_cpu_threads_per_process=8 "./sd-scripts/train_network.py" `
+  --config_file=$config_file `
+  --sample_prompts=$sample_prompts `
+  $ext_args
+
+Write-Output "Train finished"
+Read-Host | Out-Null ;

--- a/train_by_toml.sh
+++ b/train_by_toml.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# LoRA train script by @Akegarasu
+
+multi_gpu = 0		 # multi gpu | 多显卡训练 该参数仅限在显卡数 >= 2 使用
+config_file = "./toml/config_file.toml"		 # config_file | 使用toml文件指定训练参数
+sample_prompts = "./toml/sample_prompts.txt"		 # sample_prompts | 采样prompts文件,留空则不启用采样功能
+utf8 = 1		 # utf8 | 使用utf-8编码读取toml；以utf-8编码编写的、含中文的toml必须开启
+
+
+# ============= DO NOT MODIFY CONTENTS BELOW | 请勿修改下方内容 =====================
+
+export HF_HOME="huggingface"
+export TF_CPP_MIN_LOG_LEVEL=3
+
+
+extArgs=()
+launchArgs=()
+
+
+if [[ $multi_gpu == 1 ]]; then launchArgs+=("--multi_gpu"); fi
+if [[ $utf8 == 1 ]]; then export PYTHONUTF8=1 ; fi
+
+# run train
+accelerate launch ${launchArgs[@]} --num_cpu_threads_per_process=8 "./sd-scripts/train_network.py" \
+  --config_file=$config_file \
+  --sample_prompts=$sample_prompts \
+  ${extArgs[@]}


### PR DESCRIPTION
- 目前观察到相对于命令行方式，toml方式的可读性不错。

- [WSH032/kohya-config-webui](https://github.com/WSH032/kohya-config-webui)这个gradio脚本支持以SD-Webui扩展或者直接本地部署的方式交互式生成toml文件。

- 我更倾向（我在编写的gradio脚本里指定的也是）用UTF8的方式生成文本文件，这样可以在Colab里通用。

-   但是这导致了一个问题，python在中文语言的windows中读取文本文件的默认方式是GBK编码，而GBK读取带中文内容的UTF8的时候会报错，所以[train_by_toml.sh](train_by_toml.sh)和[train_by_toml.ps1](train_by_toml.ps1)里我指定了python的默认编码方式为UTF8。你们觉得呢？