### PR TITLE
将train_by_toml.ps1的编码换成GB18030

### DIFF
--- a/train_by_toml.ps1
+++ b/train_by_toml.ps1
@@ -1,12 +1,12 @@
 # LoRA train script by @Akegarasu
 
-$multi_gpu = 0		 # multi gpu | å¤šæ˜¾å¡è®­ç»ƒ è¯¥å‚æ•°ä»…é™åœ¨æ˜¾å¡æ•° >= 2 ä½¿ç”¨
-$config_file = "./toml/default.toml"		 # config_file | ä½¿ç”¨tomlæ–‡ä»¶æŒ‡å®šè®­ç»ƒå‚æ•°
-$sample_prompts = "./toml/sample_prompts.txt"		 # sample_prompts | é‡‡æ ·promptsæ–‡ä»¶,ç•™ç©ºåˆ™ä¸å¯ç”¨é‡‡æ ·åŠŸèƒ½
-$utf8 = 1		 # utf8 | ä½¿ç”¨utf-8ç¼–ç è¯»å–tomlï¼›ä»¥utf-8ç¼–ç ç¼–å†™çš„ã€å«ä¸­æ–‡çš„tomlå¿…é¡»å¼€å¯
+$multi_gpu = 0		 # multi gpu | ¶àÏÔ¿¨ÑµÁ· ¸Ã²ÎÊı½öÏŞÔÚÏÔ¿¨Êı >= 2 Ê¹ÓÃ
+$config_file = "./toml/default.toml"		 # config_file | Ê¹ÓÃtomlÎÄ¼şÖ¸¶¨ÑµÁ·²ÎÊı
+$sample_prompts = "./toml/sample_prompts.txt"		 # sample_prompts | ²ÉÑùpromptsÎÄ¼ş,Áô¿ÕÔò²»ÆôÓÃ²ÉÑù¹¦ÄÜ
+$utf8 = 1		 # utf8 | Ê¹ÓÃutf-8±àÂë¶ÁÈ¡toml£»ÒÔutf-8±àÂë±àĞ´µÄ¡¢º¬ÖĞÎÄµÄtoml±ØĞë¿ªÆô
 
 
-# ============= DO NOT MODIFY CONTENTS BELOW | è¯·å‹¿ä¿®æ”¹ä¸‹æ–¹å†…å®¹ =====================
+# ============= DO NOT MODIFY CONTENTS BELOW | ÇëÎğĞŞ¸ÄÏÂ·½ÄÚÈİ =====================
 
 # Activate python venv
 .\venv\Scripts\activate


### PR DESCRIPTION
原先的ps1文件是用UTF8编码的
```shell
$config_file = "./toml/default.toml"		 # config_file | 使用toml文件指定训练参数
$sample_prompts = "./toml/sample_prompts.txt"		 # sample_prompts | 采样prompts文件,留空则不启用采样功能
```
这两行如果出现中文路径会报错，现在换成了GB18030