### PR TITLE
[*] fix torchvision version

### DIFF
--- a/install-cn.ps1
+++ b/install-cn.ps1
@@ -31,7 +31,7 @@ Set-Location .\sd-scripts
 Write-Output "安装程序所需依赖 (已进行国内加速，若在国外或无法使用加速源请换用 install.ps1 脚本)"
 $install_torch = Read-Host "是否需要安装 Torch+xformers? [y/n] (默认为 y)"
 if ($install_torch -eq "y" -or $install_torch -eq "Y" -or $install_torch -eq ""){
-    pip install torch==2.2.1+cu118 torchvision==0.16.1+cu118 -f https://mirror.sjtu.edu.cn/pytorch-wheels/torch_stable.html
+    pip install torch==2.2.1+cu118 torchvision==0.17.1+cu118 -f https://mirror.sjtu.edu.cn/pytorch-wheels/torch_stable.html
     Check "torch 安装失败，请删除 venv 文件夹后重新运行。"
     pip install -U -I --no-deps xformers==0.0.23+cu118
     Check "xformers 安装失败。"

--- a/install.bash
+++ b/install.bash
@@ -32,11 +32,11 @@ echo "Cuda Version:$cuda_version"
 
 if (( cuda_major_version >= 12 )); then
     echo "install torch 2.2.1+cu121"
-    pip install torch==2.2.1+cu121 torchvision==0.16.1+cu121 --extra-index-url https://download.pytorch.org/whl/cu121
+    pip install torch==2.2.1+cu121 torchvision==0.17.1+cu121 --extra-index-url https://download.pytorch.org/whl/cu121
     pip install --no-deps xformers==0.0.23
 elif (( cuda_major_version == 11 && cuda_minor_version >= 8 )); then
     echo "install torch 2.2.1+cu118"
-    pip install torch==2.2.1+cu118 torchvision==0.16.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
+    pip install torch==2.2.1+cu118 torchvision==0.17.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
     pip install --no-deps xformers==0.0.23+cu118
 elif (( cuda_major_version == 11 && cuda_minor_version >= 6 )); then
     echo "install torch 1.12.1+cu116"


### PR DESCRIPTION
I encountered an error when I used Python 3.10.0 running install-cn.ps1
```
ERROR: Cannot install torch==2.2.1+cu118 and torchvision==0.16.1+cu118 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested torch==2.2.1+cu118
    torchvision 0.16.1+cu118 depends on torch==2.1.1+cu118

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
```

I found torchvision versions list corresponding torch versions list from : https://github.com/pytorch/vision, I think the torch version ==  2.2.1 corresponding torchvision version == 0.17.