### PR TITLE
[install.bash] Get CUDA version by 'nvidia-smi'

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -24,7 +24,7 @@ fi
 
 echo "Installing torch & xformers..."
 
-cuda_version=$(nvcc --version | grep 'release' | sed -n -e 's/^.*release \([0-9]\+\.[0-9]\+\),.*$/\1/p')
+cuda_version=$(nvidia-smi | grep -oiP 'CUDA Version: \K[\d\.]+')
 cuda_major_version=$(echo "$cuda_version" | awk -F'.' '{print $1}')
 cuda_minor_version=$(echo "$cuda_version" | awk -F'.' '{print $2}')
 


### PR DESCRIPTION
First of all, I appreciate your tool; it's fantastic. 

In many scenarios, there's a preference to run SD-Trainer within a container. For this setup, the installation process as outlined in the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) is followed.
It's important to note that `nvcc` is not available when using the `Nvidia Container Runtime`.
In these instances, utilizing `nvidia-smi` to determine the CUDA version becomes a more universally applicable approach.

---

首先，很感谢你的工具，它很棒🎉。

在许多情况下，人们倾向于在容器中运行 SD-Trainer。对于这种设置，安装过程遵循[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)的指南。
当使用`Nvidia Container Runtime`时，`nvcc` 是不可用的。
在这些情况下，使用`nvidia-smi`来确定 CUDA 版本应该更适用些。