### PR TITLE
解决虚拟显示卡下无法正确获得cuda版本的问题

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -25,10 +25,15 @@ fi
 echo "Installing torch & xformers..."
 
 cuda_version=$(nvidia-smi | grep -oiP 'CUDA Version: \K[\d\.]+')
+
+if [ -z "$cuda_version" ]; then
+    cuda_version=$(nvcc --version | grep -oiP 'release \K[\d\.]+')
+fi
 cuda_major_version=$(echo "$cuda_version" | awk -F'.' '{print $1}')
 cuda_minor_version=$(echo "$cuda_version" | awk -F'.' '{print $2}')
 
-echo "Cuda Version:$cuda_version"
+echo "CUDA Version: $cuda_version"
+
 
 if (( cuda_major_version >= 12 )); then
     echo "install torch 2.2.1+cu121"


### PR DESCRIPTION
在虚拟显示卡下无法通过`nvidia-smi`命令获得CUDA的版本信息，如图：
![image](https://github.com/Akegarasu/lora-scripts/assets/9147956/e7ee2bf6-a36e-4d52-b35e-7d6faa6395fc)
修复后的代码首先考虑采用`nvidia-smi`获取版本信息，如果无法获取，再采用`nvcc --version`获得版本信息。


