### PR TITLE
fix lora-flux-master

### DIFF
--- a/mikazuki/schema/lora-flux-master.ts
+++ b/mikazuki/schema/lora-flux-master.ts
@@ -28,7 +28,7 @@ Schema.intersect([
         enable_bucket: Schema.boolean().default(true).description("启用 arb 桶以允许非固定宽高比的图片"),
         min_bucket_reso: Schema.number().default(256).description("arb 桶最小分辨率"),
         max_bucket_reso: Schema.number().default(2048).description("arb 桶最大分辨率"),
-        bucket_reso_steps: Schema.number().default(32).description("arb 桶分辨率划分单位，SDXL 可以使用 32 (SDXL低于32时失效)"),
+        bucket_reso_steps: Schema.number().default(64).description("arb 桶分辨率划分单位，FLUX 必须为 64 的倍数 (FLUX低于64时无法训练)"),
         bucket_no_upscale: Schema.boolean().default(true).description("arb 桶不放大图片"),
     }).description("数据集设置"),
 


### PR DESCRIPTION
flux-lora's `bucket_reso_steps` in [here](https://github.com/Akegarasu/lora-scripts/blob/main/scripts/dev/train_network.py#L99)
![image](https://github.com/user-attachments/assets/8636a116-c4dd-4cd4-8e2c-b25ba8160227)
Using the default parameters for training will result in training failure.
![B33388DF6FE840D62CDE63BA8C15DD1D](https://github.com/user-attachments/assets/1569323b-13e9-4597-bc1b-a39f56fad9f8)
So I modified this default parameter and its description.