### PR TITLE
modify some bug when create venv and train  lora using a linux system linux in China.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,8 @@ pandas
 scipy
 requests
 pillow
-numpy<=2.0
+numpy==1.26.4
+# <=2.0.0
 gradio==3.44.2
 fastapi==0.95.1
 uvicorn==0.22.0

--- a/run_gui_sourceCN.sh
+++ b/run_gui_sourceCN.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+
+# 激活虚拟环境
+source "./venv/bin/activate"
+
+# 环境变量
+export HF_HOME=huggingface
+# 国内hg镜像
+export HF_ENDPOINT=https://hf-mirror.com
+export PYTHONUTF8=1
+
+python gui.py --listen --tensorboard-port 6006 --port 28000 "$@"
+
+


### PR DESCRIPTION
修改了numpy指定版本，此问题可能导致虚拟环境及docker环境创建时报错。
新增了linux系统启动gui界面脚本run_gui_sourceCN.sh #增加了自动激活虚拟环境与hg镜像站环境兼容，在国内服务器上也可以自动下载部分必要模块啦。