### PR TITLE
新增lumina2-lora训练的部分支持

### DIFF
--- a/mikazuki/schema/lumina2-lora.ts
+++ b/mikazuki/schema/lumina2-lora.ts
@@ -1,0 +1,99 @@
+//使用sd-script的配置
+Schema.intersect([
+    Schema.object({
+        model_train_type: Schema.string().default("lumina-lora").disabled().description("训练种类"),
+        pretrained_model_name_or_path: Schema.string().role('filepicker', { type: "model-file" }).default("./sd-models/model.safetensors").description("Lumina 模型路径"),
+        ae: Schema.string().role('filepicker', { type: "model-file" }).description("AE 模型文件路径"),
+        gemma2: Schema.string().role('filepicker', { type: "model-file" }).description("gemma2 模型文件路径"),
+        resume: Schema.string().role('filepicker', { type: "folder" }).description("从某个 `save_state` 保存的中断状态继续训练，填写文件路径"),
+    }).description("训练用模型"),
+
+    Schema.object({
+        timestep_sampling: Schema.union(["sigma", "uniform", "sigmoid", "shift", "nextdit_shift"]).default("nextdit_shift").description("时间步采样"),
+        sigmoid_scale: Schema.number().step(0.001).default(1.0).description("sigmoid 缩放"),
+        model_prediction_type: Schema.union(["raw", "additive", "sigma_scaled"]).default("raw").description("模型预测类型"),
+        discrete_flow_shift: Schema.number().step(0.001).default(3.185).description("Euler 调度器离散流位移"),
+        //loss_type: Schema.union(["l1", "l2", "huber", "smooth_l1"]).default("l2").description("损失函数类型"),
+        guidance_scale: Schema.number().step(0.01).default(1.0).description("CFG 引导缩放"),
+        use_flash_attn: Schema.boolean().default(false).description("是否使用 Flash Attention"),
+        cfg_trunc: Schema.number().step(0.01).default(0.25).description("CFG 截断"),
+        renorm_cfg: Schema.number().step(0.01).default(1.0).description("重归一化 CFG"),
+        system_prompt: Schema.string().default("You are an assistant designed to generate high-quality images based on user prompts. <Prompt Start> ").description("Gemma2b的系统提示"),
+    }).description("Lumina 专用参数"),
+
+    Schema.object(
+        UpdateSchema(SHARED_SCHEMAS.RAW.DATASET_SETTINGS, {
+            resolution: Schema.string().default("1024,1024").description("训练图片分辨率，宽x高。支持非正方形，但必须是 64 倍数。"),
+            enable_bucket: Schema.boolean().default(true).description("启用 arb 桶以允许非固定宽高比的图片"),
+            min_bucket_reso: Schema.number().default(256).description("arb 桶最小分辨率"),
+            max_bucket_reso: Schema.number().default(2048).description("arb 桶最大分辨率"),
+            bucket_reso_steps: Schema.number().default(64).description("arb 桶分辨率划分单位"),
+        })
+    ).description("数据集设置"),
+
+    // 保存设置
+    SHARED_SCHEMAS.SAVE_SETTINGS,
+
+    Schema.object({
+        max_train_epochs: Schema.number().min(1).default(10).description("最大训练 epoch（轮数）"),
+        train_batch_size: Schema.number().min(1).default(2).description("批量大小, 越高显存占用越高"),
+        gradient_checkpointing: Schema.boolean().default(true).description("梯度检查点"),
+        gradient_accumulation_steps: Schema.number().min(1).default(1).description("梯度累加步数"),
+        network_train_unet_only: Schema.boolean().default(true).description("仅训练 U-Net"),
+        network_train_text_encoder_only: Schema.boolean().default(false).description("仅训练文本编码器"),
+    }).description("训练相关参数"),
+
+    // 学习率&优化器设置
+    SHARED_SCHEMAS.LR_OPTIMIZER,
+
+    Schema.intersect([
+        Schema.object({
+            network_module: Schema.union(["networks.lora_lumina", "networks.oft_lumina", "lycoris.kohya"]).default("networks.lora_lumina").description("训练网络模块"),
+            network_weights: Schema.string().role('filepicker').description("从已有的 LoRA 模型上继续训练，填写路径"),
+            network_dim: Schema.number().min(1).default(16).description("网络维度，常用 4~128，不是越大越好, 低dim可以降低显存占用"),
+            network_alpha: Schema.number().min(1).default(8).description("常用值：等于 network_dim 或 network_dim*1/2 或 1。使用较小的 alpha 需要提升学习率"),
+            network_dropout: Schema.number().step(0.01).default(0).description('dropout 概率 （与 lycoris 不兼容，需要用 lycoris 自带的）'),
+            scale_weight_norms: Schema.number().step(0.01).min(0).default(1.0).description("最大范数正则化。如果使用，推荐为 1"),
+            network_args_custom: Schema.array(String).role('table').description('自定义 network_args，一行一个'),
+            enable_base_weight: Schema.boolean().default(false).description('启用基础权重（差异炼丹）'),
+        }).description("网络设置"),
+
+        // lycoris 参数
+        SHARED_SCHEMAS.LYCORIS_MAIN,
+        SHARED_SCHEMAS.LYCORIS_LOKR,
+
+        SHARED_SCHEMAS.NETWORK_OPTION_BASEWEIGHT,
+    ]),
+
+    // 预览图设置
+    SHARED_SCHEMAS.PREVIEW_IMAGE,
+
+    // 日志设置
+    SHARED_SCHEMAS.LOG_SETTINGS,
+
+    // caption 选项
+    Schema.object(UpdateSchema(SHARED_SCHEMAS.RAW.CAPTION_SETTINGS, {}, ["max_token_length"])).description("caption（Tag）选项"),
+
+    // 噪声设置
+    SHARED_SCHEMAS.NOISE_SETTINGS,
+
+    // 数据增强
+    SHARED_SCHEMAS.DATA_ENCHANCEMENT,
+
+    // 其他选项
+    SHARED_SCHEMAS.OTHER,
+
+    // 速度优化选项
+    Schema.object(
+        UpdateSchema(SHARED_SCHEMAS.RAW.PRECISION_CACHE_BATCH, {
+            fp8_base: Schema.boolean().default(false).description("对基础模型使用 FP8 精度"), // lumina 默认为 false
+            fp8_base_unet: Schema.boolean().default(false).description("仅对 U-Net 使用 FP8 精度（CLIP-L不使用）"), // lumina 默认为 false
+            sdpa: Schema.boolean().default(true).description("启用 sdpa"), // 脚本中未明确指定，但通常建议开启
+            cache_text_encoder_outputs: Schema.boolean().default(true).description("缓存文本编码器的输出，减少显存使用。使用时需要关闭 shuffle_caption"),
+            cache_text_encoder_outputs_to_disk: Schema.boolean().default(true).description("缓存文本编码器的输出到磁盘"),
+        }, ["xformers"])
+    ).description("速度优化选项"),
+
+    // 分布式训练
+    SHARED_SCHEMAS.DISTRIBUTED_TRAINING
+]); 

--- a/mikazuki/utils/train_utils.py
+++ b/mikazuki/utils/train_utils.py
@@ -19,10 +19,18 @@ class ModelType(Enum):
     SDXL = 3
     SD3 = 4
     FLUX = 5
+    LUMINA = 6
     LoRA = 10
 
 
 MODEL_SIGNATURE = [
+    {
+        "type": ModelType.LUMINA,
+        "signature": [
+            "cap_embedder.0.weight",
+            "context_refiner.0.attention.k_norm.weight",
+        ]
+    },
     {
         "type": ModelType.FLUX,
         "signature": [
@@ -143,8 +151,8 @@ def validate_model(model_name: str, training_type: str = "sd-lora"):
         if model_type == ModelType.UNKNOWN:
             log.error(f"Can't match model type from {model_name}")
 
-        if model_type not in [ModelType.SD15, ModelType.SD2, ModelType.SD3, ModelType.SDXL, ModelType.FLUX]:
-            return False, "Pretrained model is not a Stable Diffusion or Flux checkpoint / 校验失败：底模不是 Stable Diffusion 或 Flux 模型"
+        if model_type not in [ModelType.SD15, ModelType.SD2, ModelType.SD3, ModelType.SDXL, ModelType.FLUX, ModelType.LUMINA]:
+            return False, "Pretrained model is not a Stable Diffusion, Flux or Lumina checkpoint / 校验失败：底模不是 Stable Diffusion, Flux 或 Lumina 模型"
 
         if model_type == ModelType.SDXL and training_type == "sd-lora":
             return False, "Pretrained model is SDXL, but you are training with SD1.5 LoRA / 校验失败：你选择的是 SD1.5 LoRA 训练，但预训练模型是 SDXL。请前往专家模式选择正确的模型种类。"


### PR DESCRIPTION
由于无法直接修改前端页面来加入新的训练选项，我按照 sd-script 的参数要求，创建了 lumina2-lora 文件。此文件用于训练 Lumina2 的 LoRA，并在本地成功运行。需要说明的是，本地环境的成功运行，得益于我对代码（包括子模块代码）所做的较多修改，这些本地特定的改动可能未完全包含在此次提交中。