### PR TITLE
fix: replace deprecated locale.getdefaultlocale() with getlocale()

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -30,6 +30,13 @@ def run_tensorboard():
     subprocess.Popen([sys.executable, "-m", "tensorboard.main", "--logdir", "logs",
                      "--host", args.tensorboard_host, "--port", str(args.tensorboard_port)])
 
+def get_locale_compat():
+    lang = os.environ.get("LC_ALL") or os.environ.get("LC_CTYPE") or os.environ.get("LANG")
+    if lang:
+        lang = locale.normalize(lang).split('.')[0]
+    else:
+        lang = 'C'
+    return lang
 
 @catch_exception
 def run_tag_editor():
@@ -44,11 +51,10 @@ def run_tag_editor():
     if args.localization:
         cmd.extend(["--localization", args.localization])
     else:
-        l = locale.getlocale()[0]
+        l = get_locale_compat()
         if l and l.startswith("zh"):
             cmd.extend(["--localization", "zh-Hans"])
     subprocess.Popen(cmd)
-
 
 def launch():
     log.info("Starting SD-Trainer Mikazuki GUI...")

--- a/gui.py
+++ b/gui.py
@@ -44,7 +44,7 @@ def run_tag_editor():
     if args.localization:
         cmd.extend(["--localization", args.localization])
     else:
-        l = locale.getdefaultlocale()[0]
+        l = locale.getlocale()[0]
         if l and l.startswith("zh"):
             cmd.extend(["--localization", "zh-Hans"])
     subprocess.Popen(cmd)

--- a/gui.py
+++ b/gui.py
@@ -35,7 +35,7 @@ def get_locale_compat():
     if lang:
         lang = locale.normalize(lang).split('.')[0]
     else:
-        lang = 'C'
+        lang = locale.getlocale()[0] or 'C'
     return lang
 
 @catch_exception


### PR DESCRIPTION
Although Python 3.11 still supports locale.getdefaultlocale(), it is deprecated and will be removed in Python 3.15+. This change avoids the warning and improves forward compatibility.